### PR TITLE
Themes

### DIFF
--- a/NodeGraphQt/base/graph.py
+++ b/NodeGraphQt/base/graph.py
@@ -968,7 +968,9 @@ class NodeGraph(QtCore.QObject):
         node.NODE_NAME = self.get_unique_name(node.NODE_NAME)
         node.model._graph_model = self.model
         node.model.name = node.NODE_NAME
-        node.set_default_theme(self._default_theme)
+        default_theme_op = getattr(node, "set_default_theme", None)
+        if default_theme_op:
+            node.set_default_theme(self._default_theme)
         node.update()
 
         if push_undo:

--- a/NodeGraphQt/base/graph.py
+++ b/NodeGraphQt/base/graph.py
@@ -136,6 +136,8 @@ class NodeGraph(QtCore.QObject):
 
         self._sub_graphs = {}
 
+        self._default_theme = {}
+        
         self._viewer = (
             kwargs.get('viewer') or NodeViewer(undo_stack=self._undo_stack))
 
@@ -922,6 +924,8 @@ class NodeGraph(QtCore.QObject):
             if pos:
                 node.model.pos = [float(pos[0]), float(pos[1])]
 
+            if node_type != 'Backdrop':
+                node._view.set_default_theme(self._default_theme)
             node.update()
 
             if push_undo:
@@ -964,6 +968,7 @@ class NodeGraph(QtCore.QObject):
         node.NODE_NAME = self.get_unique_name(node.NODE_NAME)
         node.model._graph_model = self.model
         node.model.name = node.NODE_NAME
+        node.set_default_theme(self._default_theme)
         node.update()
 
         if push_undo:
@@ -1899,6 +1904,35 @@ class NodeGraph(QtCore.QObject):
         # TODO: delete sub graph hmm... not sure if I need this here.
         del sub_graph
 
+    def set_default_theme(self, theme, update_current=True):
+        """
+        Sets a default user defined theme for all new nodes and ports
+        If update_current is true then also update the exisitng nodes and ports
+
+        Args:
+            theme (dict): Dictionary containing theme item: colors, padding, margin, etc.
+        Example:
+            {'node_border_width': 0.8,
+            'node_selected_color': NodeEnum.SELECTED_COLOR.value,
+            'node_selected_border_color': NodeEnum.SELECTED_BORDER_COLOR.value,
+            'node_selected_title_color': NodeEnum.SELECTED_COLOR.value,
+            'node_selected_border_width': 1.2,                        
+            'node_name_background_padding': [3.0, 2.0],
+            'node_base_background_margin': 1.0,
+            'node_name_background_margin': 1.0,
+            'node_name_background_radius': 3.0,
+            'port_color': PortEnum.COLOR.value,
+            'port_border_color': PortEnum.BORDER_COLOR.value,
+            'port_border_size': 1.0,
+            'port_active_color': PortEnum.ACTIVE_COLOR.value,
+            'port_active_border_color': PortEnum.ACTIVE_BORDER_COLOR.value,
+            'port_hover_color': PortEnum.ACTIVE_COLOR.value,
+            'port_hover_border_color': PortEnum.HOVER_BORDER_COLOR.value}
+        """
+        self._default_theme = theme
+        for node_name, node in self._model.nodes.items():
+            if node.type_ != 'nodeGraphQt.nodes.BackdropNode':
+                node._view.set_default_theme(theme, update_current)
 
 class SubGraph(NodeGraph):
     """

--- a/NodeGraphQt/base/graph.py
+++ b/NodeGraphQt/base/graph.py
@@ -924,7 +924,7 @@ class NodeGraph(QtCore.QObject):
             if pos:
                 node.model.pos = [float(pos[0]), float(pos[1])]
 
-            if node_type != 'Backdrop':
+            if getattr(node, '_view.set_default_theme', None):
                 node._view.set_default_theme(self._default_theme)
             node.update()
 
@@ -1318,8 +1318,9 @@ class NodeGraph(QtCore.QObject):
                 # set custom properties.
                 for prop, val in n_data.get('custom', {}).items():
                     node.model.set_property(prop, val)
-                    if prop in node.view.widgets:
-                        node.view.widgets[prop].set_value(val)
+                    if getattr(node.view, 'widgets', None):
+                        if prop in node.view.widgets:
+                            node.view.widgets[prop].set_value(val)
 
                 nodes[n_id] = node
                 self.add_node(node, n_data.get('pos'))

--- a/NodeGraphQt/constants.py
+++ b/NodeGraphQt/constants.py
@@ -76,6 +76,8 @@ class ViewerEnum(Enum):
     """
     #: default background color for the node graph.
     BACKGROUND_COLOR = (35, 35, 35)
+    #: default background color for the node graph.
+    BACKGROUND_COLOR_USES_PALETTE = True
     #: style node graph background with no grid or dots.
     GRID_DISPLAY_NONE = 0
     #: style node graph background with dots.

--- a/NodeGraphQt/qgraphics/node_base.py
+++ b/NodeGraphQt/qgraphics/node_base.py
@@ -45,6 +45,15 @@ class NodeItem(AbstractNodeItem):
         self._widgets = OrderedDict()
         self._proxy_mode = False
         self._proxy_mode_threshold = 70
+        self._theme = {'node_border_width': 0.8,
+                        'node_selected_color': NodeEnum.SELECTED_COLOR.value,
+                        'node_selected_border_color': NodeEnum.SELECTED_BORDER_COLOR.value,
+                        'node_selected_title_color': NodeEnum.SELECTED_COLOR.value,
+                        'node_selected_border_width': 1.2,                        
+                        'node_name_background_padding': [3.0, 2.0],
+                        'node_base_background_margin': 1.0,
+                        'node_name_background_margin': 1.0,
+                        'node_name_background_radius': 3.0}
 
     def paint(self, painter, option, widget):
         """
@@ -63,7 +72,7 @@ class NodeItem(AbstractNodeItem):
         painter.setBrush(QtCore.Qt.NoBrush)
 
         # base background.
-        margin = 1.0
+        margin = self._theme['node_base_background_margin']
         rect = self.boundingRect()
         rect = QtCore.QRectF(rect.left() + margin,
                              rect.top() + margin,
@@ -76,30 +85,30 @@ class NodeItem(AbstractNodeItem):
 
         # light overlay on background when selected.
         if self.selected:
-            painter.setBrush(QtGui.QColor(*NodeEnum.SELECTED_COLOR.value))
+            painter.setBrush(QtGui.QColor(*self._theme['node_selected_color']))
             painter.drawRoundedRect(rect, radius, radius)
 
         # node name background.
-        padding = 3.0, 2.0
+        padding = self._theme['node_name_background_padding']
+        margin = self._theme['node_name_background_margin']
+        radius = self._theme['node_name_background_radius']
         text_rect = self._text_item.boundingRect()
         text_rect = QtCore.QRectF(text_rect.x() + padding[0],
                                   rect.y() + padding[1],
                                   rect.width() - padding[0] - margin,
                                   text_rect.height() - (padding[1] * 2))
         if self.selected:
-            painter.setBrush(QtGui.QColor(*NodeEnum.SELECTED_COLOR.value))
+            painter.setBrush(QtGui.QColor(*self._theme['node_selected_title_color']))
         else:
-            painter.setBrush(QtGui.QColor(0, 0, 0, 80))
-        painter.drawRoundedRect(text_rect, 3.0, 3.0)
+            painter.setBrush(QtGui.QColor(0, 0, 0, 80))        
+        painter.drawRoundedRect(text_rect, radius, radius)
 
         # node border
         if self.selected:
-            border_width = 1.2
-            border_color = QtGui.QColor(
-                *NodeEnum.SELECTED_BORDER_COLOR.value
-            )
+            border_width = self._theme['node_selected_border_width']
+            border_color = QtGui.QColor(*self._theme['node_selected_border_color'])
         else:
-            border_width = 0.8
+            border_width = self._theme['node_border_width']
             border_color = QtGui.QColor(*self.border_color)
 
         border_rect = QtCore.QRectF(rect.left(), rect.top(),
@@ -769,6 +778,18 @@ class NodeItem(AbstractNodeItem):
             if self._widgets.get(name):
                 self._widgets[name].value = value
 
+    def set_theme_item(self, item, value):
+        if item in self._theme:
+            self._theme[item] = value
+        if item == 'node_color':
+            self.color = value
+        elif item == 'node_border_color':
+            self.border_color = value
+
+    def set_theme_items(self, theme_items):
+        for item, value in theme_items.items():
+            self.set_theme_item(item, value)
+
 
 class NodeItemVertical(NodeItem):
     """
@@ -816,7 +837,7 @@ class NodeItemVertical(NodeItem):
         # light overlay on background when selected.
         if self.selected:
             painter.setBrush(
-                QtGui.QColor(*NodeEnum.SELECTED_COLOR.value)
+                QtGui.QColor(*self._theme['node_selected_color'])
             )
             painter.drawRoundedRect(rect, radius, radius)
 
@@ -824,7 +845,7 @@ class NodeItemVertical(NodeItem):
         padding = 2.0
         height = 10
         if self.selected:
-            painter.setBrush(QtGui.QColor(*NodeEnum.SELECTED_COLOR.value))
+            painter.setBrush(QtGui.QColor(*self._theme['node_selected_color']))
         else:
             painter.setBrush(QtGui.QColor(0, 0, 0, 80))
         for y in [rect.y() + padding, rect.height() - height - 1]:
@@ -838,7 +859,7 @@ class NodeItemVertical(NodeItem):
         if self.selected:
             border_width = 1.2
             border_color = QtGui.QColor(
-                *NodeEnum.SELECTED_BORDER_COLOR.value
+                *self._theme['node_selected_border_color']
             )
         border_rect = QtCore.QRectF(rect.left(), rect.top(),
                                     rect.width(), rect.height())

--- a/NodeGraphQt/qgraphics/node_base.py
+++ b/NodeGraphQt/qgraphics/node_base.py
@@ -54,6 +54,7 @@ class NodeItem(AbstractNodeItem):
                         'node_base_background_margin': 1.0,
                         'node_name_background_margin': 1.0,
                         'node_name_background_radius': 3.0}
+        self._default_theme = {}
 
     def paint(self, painter, option, widget):
         """
@@ -646,6 +647,7 @@ class NodeItem(AbstractNodeItem):
             self._output_items[port] = text
         if self.scene():
             self.post_init()
+        port.set_theme_items(self._default_theme)
         return port
 
     def add_input(self, name='input', multi_port=False, display_name=True,
@@ -790,7 +792,15 @@ class NodeItem(AbstractNodeItem):
         for item, value in theme_items.items():
             self.set_theme_item(item, value)
 
-
+    def set_default_theme(self, theme, update_current=True):
+        self._default_theme = theme
+        if update_current:
+            self.set_theme_items(theme)
+            for port in self._input_items:
+                port.set_theme_items(theme)
+            for port in self._output_items:
+                port.set_theme_items(theme)
+            
 class NodeItemVertical(NodeItem):
     """
     Vertical Node item.

--- a/NodeGraphQt/qgraphics/port.py
+++ b/NodeGraphQt/qgraphics/port.py
@@ -25,9 +25,14 @@ class PortItem(QtWidgets.QGraphicsItem):
         self._hovered = False
         self._name = 'port'
         self._display_name = True
-        self._color = PortEnum.COLOR.value
-        self._border_color = PortEnum.BORDER_COLOR.value
-        self._border_size = 1
+        self._theme = {'port_color': PortEnum.COLOR.value,
+                       'port_border_color': PortEnum.BORDER_COLOR.value,
+                       'port_border_size': 1.0,
+                       'port_active_color': PortEnum.ACTIVE_COLOR.value,
+                       'port_active_border_color': PortEnum.ACTIVE_BORDER_COLOR.value,
+                       'port_hover_color': PortEnum.ACTIVE_COLOR.value,
+                       'port_hover_border_color': PortEnum.HOVER_BORDER_COLOR.value                       
+                       }
         self._port_type = None
         self._multi_connection = False
         self._locked = False
@@ -70,14 +75,14 @@ class PortItem(QtWidgets.QGraphicsItem):
         port_rect = QtCore.QRectF(rect_x, rect_y, rect_w, rect_h)
 
         if self._hovered:
-            color = QtGui.QColor(*PortEnum.HOVER_COLOR.value)
-            border_color = QtGui.QColor(*PortEnum.HOVER_BORDER_COLOR.value)
+            color = QtGui.QColor(*self._theme['port_hover_color'])
+            border_color = QtGui.QColor(*self._theme['port_hover_border_color'])
         elif self.connected_pipes:
-            color = QtGui.QColor(*PortEnum.ACTIVE_COLOR.value)
-            border_color = QtGui.QColor(*PortEnum.ACTIVE_BORDER_COLOR.value)
+            color = QtGui.QColor(*self._theme['port_active_color'])
+            border_color = QtGui.QColor(*self._theme['port_active_border_color'])
         else:
-            color = QtGui.QColor(*self.color)
-            border_color = QtGui.QColor(*self.border_color)
+            color = QtGui.QColor(*self._theme['port_color'])
+            border_color = QtGui.QColor(*self._theme['port_border_color'])
 
         pen = QtGui.QPen(border_color, 1.8)
         painter.setPen(pen)
@@ -196,28 +201,28 @@ class PortItem(QtWidgets.QGraphicsItem):
 
     @property
     def color(self):
-        return self._color
+        return self._theme['port_color']
 
     @color.setter
     def color(self, color=(0, 0, 0, 255)):
-        self._color = color
+        self._theme['port_color'] = color
         self.update()
 
     @property
     def border_color(self):
-        return self._border_color
+        return self._theme['port_border_color']
 
     @border_color.setter
     def border_color(self, color=(0, 0, 0, 255)):
-        self._border_color = color
+        self._theme['port_border_color'] = color
 
     @property
     def border_size(self):
-        return self._border_size
+        return self._theme['port_border_size']
 
     @border_size.setter
     def border_size(self, size=2):
-        self._border_size = size
+        self._theme['port_border_size'] = size
 
     @property
     def locked(self):
@@ -276,6 +281,14 @@ class PortItem(QtWidgets.QGraphicsItem):
         port.update()
         self.update()
 
+    def set_theme_item(self, item, value):
+        if item in self._theme:
+            self._theme[item] = value
+
+    def set_theme_items(self, theme_items):
+        for item, value in theme_items.items():
+            if item in self._theme:
+                self._theme[item] = value
 
 class CustomPortItem(PortItem):
     """

--- a/NodeGraphQt/widgets/actions.py
+++ b/NodeGraphQt/widgets/actions.py
@@ -10,11 +10,16 @@ class BaseMenu(QtWidgets.QMenu):
         super(BaseMenu, self).__init__(*args, **kwargs)
         text_color = self.palette().text().color().getRgb()
         selected_color = self.palette().highlight().color().getRgb()
+        if ViewerEnum.BACKGROUND_COLOR_USES_PALETTE.value:
+            window_background = self.palette().window().color().getRgb()
+        else:
+            window_background = ViewerEnum.BACKGROUND_COLOR.value
+        
         style_dict = {
             'QMenu': {
                 'color': 'rgb({0},{1},{2})'.format(*text_color),
                 'background-color': 'rgb({0},{1},{2})'.format(
-                    *ViewerEnum.BACKGROUND_COLOR.value
+                    *window_background
                 ),
                 'border': '1px solid rgba({0},{1},{2},30)'.format(*text_color),
                 'border-radius': '3px',

--- a/basic_example.py
+++ b/basic_example.py
@@ -30,7 +30,25 @@ if __name__ == '__main__':
 
     # create graph controller.
     graph = NodeGraph()
-
+    graph.set_background_color(125, 125, 125)
+    graph.set_default_theme({
+             'node_border_width': 0.8,
+             'node_selected_color': (255, 255, 255, 30),
+             'node_selected_border_color': (45, 109, 209, 255),
+             'node_selected_title_color': (45, 109, 209, 255),
+             'node_selected_border_width': 2.5,                        
+             'node_name_background_padding': [0.0, 0.0],
+             'node_base_background_margin': 1.0,
+             'node_name_background_margin': 0.0,
+             'node_name_background_radius': 2.0,
+            'port_color': (0, 0, 0, 255),
+            'port_border_color': (125, 125, 125, 255),
+            'port_border_size': 1.0,
+            'port_active_color': (255, 255, 255, 255),
+            'port_active_border_color': (125, 125, 125, 255),
+            'port_hover_color': (45, 109, 209, 255),
+            'port_hover_border_color': (45, 109, 209, 255)
+            })
     # registered example nodes.
     graph.register_nodes([
         basic_nodes.BasicNodeA,


### PR DESCRIPTION
Allows node and port style to be set

graph.set_default_theme({
             'node_border_width': 0.8,
             'node_selected_color': (255, 255, 255, 30),
             'node_selected_border_color': (45, 109, 209, 255),
             'node_selected_title_color': (45, 109, 209, 255),
             'node_selected_border_width': 2.5,                        
             'node_name_background_padding': [0.0, 0.0],
             'node_base_background_margin': 1.0,
             'node_name_background_margin': 0.0,
             'node_name_background_radius': 2.0,
            'port_color': (0, 0, 0, 255),
            'port_border_color': (125, 125, 125, 255),
            'port_border_size': 1.0,
            'port_active_color': (255, 255, 255, 255),
            'port_active_border_color': (125, 125, 125, 255),
            'port_hover_color': (45, 109, 209, 255),
            'port_hover_border_color': (45, 109, 209, 255)
            })